### PR TITLE
add / to css paths in layout.hbs

### DIFF
--- a/templates/mvcjshbs/Server/Views/layout.hbs
+++ b/templates/mvcjshbs/Server/Views/layout.hbs
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{title}}</title>
      <!-- CSS Section -->
-    <link rel="stylesheet" href="bootstrap/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="@fortawesome/fontawesome-free/css/all.min.css">
-    <link rel="stylesheet" href="Content/app.css">
+    <link rel="stylesheet" href="/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/@fortawesome/fontawesome-free/css/all.min.css">
+    <link rel="stylesheet" href="/Content/app.css">
 </head>
 <body>
     <main>

--- a/templates/mvctschbs/Server/Views/layout.hbs
+++ b/templates/mvctschbs/Server/Views/layout.hbs
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{title}}</title>
      <!-- CSS Section -->
-    <link rel="stylesheet" href="bootstrap/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="@fortawesome/fontawesome-free/css/all.min.css">
-    <link rel="stylesheet" href="Content/app.css">
+    <link rel="stylesheet" href="/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/@fortawesome/fontawesome-free/css/all.min.css">
+    <link rel="stylesheet" href="/Content/app.css">
 </head>
 <body>
     


### PR DESCRIPTION
Modified layout.hbs css paths to start with '/':

    <link rel="stylesheet" href="/bootstrap/dist/css/bootstrap.min.css">
    <link rel="stylesheet" href="/@fortawesome/fontawesome-free/css/all.min.css">
    <link rel="stylesheet" href="/Content/app.css">

Original Paths break in any paths inside a controller other than the route path otherwise (i.e. /media works but not /media/create).  Changes applied to both hbs versions (js + ts)